### PR TITLE
 Fix error -  cannot connect an Oracle database

### DIFF
--- a/src/main/java/org/wso2/carbon/inbound/poll/dbeventlistener/DBEventPollingConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/poll/dbeventlistener/DBEventPollingConsumer.java
@@ -380,7 +380,7 @@ public class DBEventPollingConsumer extends GenericPollingConsumer {
             }
             statement = connection.prepareStatement(connectionValidationQuery);
             rs = statement.executeQuery(connectionValidationQuery);
-            if(rs == null || rs.first()) {
+            if (rs == null || rs.next()) {
                 return true;
             }
         } catch (SQLException e) {


### PR DESCRIPTION
## Purpose
> The following error prevented the use of an Oracle database with the extension.

```
ERROR

{org.wso2.carbon.inbound.poll.dbeventlistener.DBEventPollingConsumer}
- Error while checking the 
database connection.
java.sql.SQLException: Invalid operation for forward only resultset : first
at oracle.jdbc.driver.BaseResultSet.first(BaseResultSet.java:87)
at 
org.wso2.carbon.inbound.poll.dbeventlistener.DBEventPollingConsumer.isConnectionAlive(DBEventP
ollingConsumer.java:383)
at 
org.wso2.carbon.inbound.poll.dbeventlistener.DBEventPollingConsumer.poll(DBEventPollingConsume
r.java:343)
```

This PR resolves the issue (Resolves #12).