### PR TITLE
Fix null in inbound endpoint name.

### DIFF
--- a/src/main/java/org/wso2/carbon/inbound/poll/dbeventlistener/DBEventConstants.java
+++ b/src/main/java/org/wso2/carbon/inbound/poll/dbeventlistener/DBEventConstants.java
@@ -32,5 +32,6 @@ public class DBEventConstants {
     public static final String REGISTRY_PATH = "registryPath";
     public static final String TABLE_PRIMARY_KEY = "primaryKey";
     public static final String CONNECTION_VALIDATION_QUERY = "connectionValidationQuery";
+    public static final String INBOUND_ENDPOINT_NAME = "inbound.endpoint.name";
 }
 

--- a/src/main/java/org/wso2/carbon/inbound/poll/dbeventlistener/DBEventPollingConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/poll/dbeventlistener/DBEventPollingConsumer.java
@@ -105,6 +105,7 @@ public class DBEventPollingConsumer extends GenericPollingConsumer {
         String query = null;
         DBEventRegistryHandler dbEventListnerRegistryHandler = new DBEventRegistryHandler(synapseEnvironment);
         msgCtx = createMessageContext();
+        msgCtx.setProperty(DBEventConstants.INBOUND_ENDPOINT_NAME, inboundName);
         if (injectingSeq == null || injectingSeq.equals("")) {
             log.error("Sequence name not specified. Sequence : " + injectingSeq
                     + " in the inbound endpoint configuration " + inboundName);


### PR DESCRIPTION
## Purpose
> In current behaviour there will be null values in the component name of the database event inbound endpoint.

## Goals
> The suggested fix will set the inbound endpoint name to the message context and when publishing stats to the analytics the inbound name will be captured from the message context.

## Approach
> In the default way the inbound name was not set to the message context and in the suggested fix it was set to the message context.