### PR TITLE
Fix null in inbound endpoint name.

### DIFF
--- a/src/main/java/org/wso2/carbon/inbound/poll/dbeventlistener/DBEventConstants.java
+++ b/src/main/java/org/wso2/carbon/inbound/poll/dbeventlistener/DBEventConstants.java
@@ -32,5 +32,6 @@ public class DBEventConstants {
     public static final String REGISTRY_PATH = "registryPath";
     public static final String TABLE_PRIMARY_KEY = "primaryKey";
     public static final String CONNECTION_VALIDATION_QUERY = "connectionValidationQuery";
+    public static final String INBOUND_ENDPOINT_NAME = "inbound.endpoint.name";
 }
 

--- a/src/main/java/org/wso2/carbon/inbound/poll/dbeventlistener/DBEventPollingConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/poll/dbeventlistener/DBEventPollingConsumer.java
@@ -29,6 +29,7 @@ import org.apache.synapse.core.SynapseEnvironment;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.mediators.base.SequenceMediator;
 import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.inbound.endpoint.protocol.generic.GenericConstants;
 import org.wso2.carbon.inbound.endpoint.protocol.generic.GenericPollingConsumer;
 
 import java.sql.PreparedStatement;
@@ -59,6 +60,7 @@ public class DBEventPollingConsumer extends GenericPollingConsumer {
     private String primaryKeyFromConfig = "";
     private String connectionValidationQuery = null;
     private String tableName = null;
+    private String name;
 
 
     /**
@@ -84,6 +86,7 @@ public class DBEventPollingConsumer extends GenericPollingConsumer {
         registryPath = properties.getProperty(DBEventConstants.REGISTRY_PATH);
         primaryKeyFromConfig = properties.getProperty(DBEventConstants.TABLE_PRIMARY_KEY);
         connectionValidationQuery = properties.getProperty(DBEventConstants.CONNECTION_VALIDATION_QUERY);
+        this.name = name;
         if (StringUtils.isEmpty(registryPath)) {
             registryPath = name;
         }
@@ -105,6 +108,7 @@ public class DBEventPollingConsumer extends GenericPollingConsumer {
         String query = null;
         DBEventRegistryHandler dbEventListnerRegistryHandler = new DBEventRegistryHandler(synapseEnvironment);
         msgCtx = createMessageContext();
+        msgCtx.setProperty("inbound.endpoint.name", name);
         if (injectingSeq == null || injectingSeq.equals("")) {
             log.error("Sequence name not specified. Sequence : " + injectingSeq
                     + " in the inbound endpoint configuration " + inboundName);

--- a/src/main/java/org/wso2/carbon/inbound/poll/dbeventlistener/DBEventPollingConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/poll/dbeventlistener/DBEventPollingConsumer.java
@@ -59,8 +59,6 @@ public class DBEventPollingConsumer extends GenericPollingConsumer {
     private String primaryKeyFromConfig = "";
     private String connectionValidationQuery = null;
     private String tableName = null;
-    private String epName;
-
 
     /**
      * @param properties
@@ -85,7 +83,6 @@ public class DBEventPollingConsumer extends GenericPollingConsumer {
         registryPath = properties.getProperty(DBEventConstants.REGISTRY_PATH);
         primaryKeyFromConfig = properties.getProperty(DBEventConstants.TABLE_PRIMARY_KEY);
         connectionValidationQuery = properties.getProperty(DBEventConstants.CONNECTION_VALIDATION_QUERY);
-        this.epName = name;
         if (StringUtils.isEmpty(registryPath)) {
             registryPath = name;
         }
@@ -107,7 +104,7 @@ public class DBEventPollingConsumer extends GenericPollingConsumer {
         String query = null;
         DBEventRegistryHandler dbEventListnerRegistryHandler = new DBEventRegistryHandler(synapseEnvironment);
         msgCtx = createMessageContext();
-        msgCtx.setProperty(DBEventConstants.INBOUND_ENDPOINT_NAME, epName);
+        msgCtx.setProperty(DBEventConstants.INBOUND_ENDPOINT_NAME, inboundName);
         if (injectingSeq == null || injectingSeq.equals("")) {
             log.error("Sequence name not specified. Sequence : " + injectingSeq
                     + " in the inbound endpoint configuration " + inboundName);

--- a/src/main/java/org/wso2/carbon/inbound/poll/dbeventlistener/DBEventPollingConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/poll/dbeventlistener/DBEventPollingConsumer.java
@@ -29,7 +29,6 @@ import org.apache.synapse.core.SynapseEnvironment;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.mediators.base.SequenceMediator;
 import org.wso2.carbon.base.MultitenantConstants;
-import org.wso2.carbon.inbound.endpoint.protocol.generic.GenericConstants;
 import org.wso2.carbon.inbound.endpoint.protocol.generic.GenericPollingConsumer;
 
 import java.sql.PreparedStatement;
@@ -60,7 +59,7 @@ public class DBEventPollingConsumer extends GenericPollingConsumer {
     private String primaryKeyFromConfig = "";
     private String connectionValidationQuery = null;
     private String tableName = null;
-    private String name;
+    private String epName;
 
 
     /**
@@ -86,7 +85,7 @@ public class DBEventPollingConsumer extends GenericPollingConsumer {
         registryPath = properties.getProperty(DBEventConstants.REGISTRY_PATH);
         primaryKeyFromConfig = properties.getProperty(DBEventConstants.TABLE_PRIMARY_KEY);
         connectionValidationQuery = properties.getProperty(DBEventConstants.CONNECTION_VALIDATION_QUERY);
-        this.name = name;
+        this.epName = name;
         if (StringUtils.isEmpty(registryPath)) {
             registryPath = name;
         }
@@ -108,7 +107,7 @@ public class DBEventPollingConsumer extends GenericPollingConsumer {
         String query = null;
         DBEventRegistryHandler dbEventListnerRegistryHandler = new DBEventRegistryHandler(synapseEnvironment);
         msgCtx = createMessageContext();
-        msgCtx.setProperty("inbound.endpoint.name", name);
+        msgCtx.setProperty(DBEventConstants.INBOUND_ENDPOINT_NAME, epName);
         if (injectingSeq == null || injectingSeq.equals("")) {
             log.error("Sequence name not specified. Sequence : " + injectingSeq
                     + " in the inbound endpoint configuration " + inboundName);


### PR DESCRIPTION
## Purpose
> In current behaviour there will be null values in the component name of the database event inbound endpoint.

## Goals
> The suggested fix will set the inbound endpoint name to the message context and when publishing stats to the analytics the inbound name will be captured from the message context.

## Approach
> In the default way the inbound name was not set to the message context and in the suggested fix it was set to the message context.